### PR TITLE
Correção de formatação de texto

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Deverá ficar assim:
 Caso seu projeto já contenha outras configurações no `<properties>`, esta deverá ser mais uma delas.
 
 
-Na sequência, procure pela área de *<build><plugins>* do seu *pom.xml* - Caso não exista, você pode criar esta na raiz do seu *pom.xml* e adicionar conforme exemplo abaixo (Já configurando o plugin do checkstyle):
+Na sequência, procure pela área de `<build><plugins>` do seu *pom.xml* - Caso não exista, você pode criar esta na raiz do seu *pom.xml* e adicionar conforme exemplo abaixo (Já configurando o plugin do checkstyle):
 
 ```
 <build>


### PR DESCRIPTION
Substituição de asterisco por sinal de crase para exibição de texto. Com asterisco o texto não era exibido no render do markdown.